### PR TITLE
[FAB2023-751] feat: KG 화면 프로토타입 2차 개발

### DIFF
--- a/frontend/components/cytoscape.vue
+++ b/frontend/components/cytoscape.vue
@@ -191,20 +191,19 @@ onMounted(() => {
       element.style("background-color", element.parent().data("childColor"));
     }
 
-    // 아래 [Issue]로 보류...
     // 부모 노드 일 때, 자식노드의 layout을 별개로 설정한다.
-    // else if (element.isParent()) {
-    //   const children = element.children();
-    //   children
-    //     .layout({
-    //       name: "grid",
-    //       fit: true,
-    //       spacingFactor: 0.2,
-    //       rows: 3,
-    //       cols: 3
-    //     })
-    //     .run();
-    // }
+    else if (element.isParent()) {
+      const children = element.children();
+      children
+        .layout({
+          name: "grid",
+          fit: true,
+          spacingFactor: 0.2,
+          rows: 3,
+          cols: 3
+        })
+        .run();
+    }
   });
 
   cy.on("tap", (event: any) => {
@@ -243,29 +242,6 @@ onMounted(() => {
       const children = evtTarget.children();
       evtTarget.style("text-valign", "top");
       children.style("display", "element");
-
-      // [Issue] 숨겨놨던 자식 노드가 보여질 때 position 위치가 엉뚱한 위치로 튀는 이슈가 있어서 아래와 같이 이슈처리함
-      // -> 이로인해 :child 노드들의 layout 세팅이 불가 (검토 필요)
-      // 원인: JavaScript 객체의 참조로 인해 콘솔 로그에서 확장할 때 최신 상태가 반영됨.
-      // 해결 방법: 객체의 값을 복사하여 로그에 출력하여 참조 문제를 피함.
-      let initialPosition = { ...evtTarget.position() };
-      // 자식 노드의 상대 위치를 유지하며 부모 노드의 위치를 변경
-      let offsetX = initialPosition.x - evtTarget.position().x;
-      let offsetY = initialPosition.y - evtTarget.position().y;
-
-      evtTarget.children().forEach((element: any) => {
-        let childPosition = element.position();
-        element.position({
-          x: childPosition.x + offsetX,
-          y: childPosition.y + offsetY
-        });
-      });
-
-      // 부모 노드의 위치를 최종적으로 설정
-      evtTarget.position({
-        x: initialPosition.x,
-        y: initialPosition.y
-      });
     }
 
     cy.elements().forEach((element: any) => {

--- a/frontend/components/cytoscape.vue
+++ b/frontend/components/cytoscape.vue
@@ -426,7 +426,9 @@ const setNodeView = (id: string, isUnChecked: boolean) => {
   const children = getChild(cy, el);
   children.forEach((c) => {
     isUnChecked ? c.hide() : c.show();
+    c.style("display", "none");
   });
+  el.style("text-valign", "center");
 };
 
 const setGraphLayout = (layout: object) => {

--- a/frontend/components/cytoscape.vue
+++ b/frontend/components/cytoscape.vue
@@ -27,8 +27,7 @@ import CONSTANTS from "@cons/constants";
 import Filter from "@comp/units/filter.vue";
 import SelectLayout from "@comp/units/selectLayout.vue";
 import useCytoscapeDragOpt from "@composables/cytoscape/dragOpt";
-const { option, getTarget, createNewEdge, getChild, getSibling, getParent } =
-  useCytoscapeDragOpt();
+
 interface Filter {
   id: string;
   label: string;
@@ -69,29 +68,15 @@ const props = defineProps({
 
 const nuxtApp = useNuxtApp();
 const cytoscapeStore = useCytoscapeStore();
+const { option, getTarget, createNewEdge, getChild, getSibling, getParent } =
+  useCytoscapeDragOpt();
 const hideNodeList = ref([]);
 const filterList = ref([]);
-const layoutObj = ref({});
-const parentColorObj = ref({});
 const mmContainer = ref(null);
 const filters = ref<Filter[]>([]);
 let highlightedNodeId = ref([]);
 let cy: any = null;
 let refinedLayoutData = ref({});
-
-const setFilters = () => {
-  filterList.value.forEach((el) => {
-    if (!el.isChild()) {
-      filters.value.push({
-        id: el.id(),
-        label: el.data().label,
-        color: el.data("colorCode"),
-        isUnChecked: false,
-        childCount: el.children().length
-      });
-    }
-  });
-};
 
 onMounted(() => {
   const cytoscape = nuxtApp.$cytoscape;
@@ -122,6 +107,7 @@ onMounted(() => {
     eles: refinedLayoutData
   };
   cy.layout(layoutOptions).run();
+
   // cy.viewport({
   //   zoom: 0.1
   // });
@@ -219,6 +205,7 @@ onMounted(() => {
       element.position({ x: 160, y: 40 });
     }
   });
+
   cy.on("tap", (event: any) => {
     let evtTarget = event.target;
 
@@ -226,10 +213,7 @@ onMounted(() => {
 
     if (evtTarget === cy) {
       cy.elements().forEach((element: any) => {
-        if (element.isNode()) {
-          element.removeClass(CONSTANTS.HIGHLIGHT);
-          element.removeClass(CONSTANTS.NOT_SELECTED);
-        } else if (element.isEdge()) {
+        if (element.isNode() || element.isEdge()) {
           element.removeClass(CONSTANTS.HIGHLIGHT);
           element.removeClass(CONSTANTS.NOT_SELECTED);
         }
@@ -368,6 +352,18 @@ onMounted(() => {
   });
 });
 
+const setFilters = () => {
+  filterList.value.forEach((el) => {
+    if (!el.isChild()) {
+      filters.value.push({
+        id: el.id(),
+        label: el.data().label,
+        color: el.data("colorCode"),
+        isUnChecked: false
+      });
+    }
+  });
+};
 const getColorCode = () => {
   return Math.floor(Math.random() * 127 + 115).toString(16);
 };
@@ -428,9 +424,21 @@ button {
   border: none;
   outline: none;
 }
+
 .part,
 #cy {
   border: 1px solid red;
+}
+
+.htmlTag {
+  font-size: 10px;
+  color: #333;
+  cursor: default;
+
+  &:hover {
+    font-size: 12px;
+    text-wrap: wrap;
+  }
 }
 
 p.htmlTag.hide {

--- a/frontend/components/cytoscape.vue
+++ b/frontend/components/cytoscape.vue
@@ -171,6 +171,7 @@ onMounted(() => {
         const parentData = el.parent().data();
         el.data(CONSTANTS.PRNT_CTGRY_ID, parentData.id);
         el.data(CONSTANTS.PRNT_CTGRY_NM, parentData.label);
+        el.style("display", "none");
       } else if (el.isParent()) {
         // 자식 노드 색상을 여기서 설정해둔다. (부모 노드와 색상 동일하게)
         // TODO : 혹은 색상 채도를 좀 낮춰서 표시 (코드가 복잡해서 보류)
@@ -236,6 +237,36 @@ onMounted(() => {
 
     cy.elements().removeClass(CONSTANTS.NOT_SELECTED);
     evtTarget.addClass(CONSTANTS.HIGHLIGHT);
+
+    if (evtTarget.isParent()) {
+      // isParent인 경우 라벨 위치 위로 + child 보이기
+      const children = evtTarget.children();
+      evtTarget.style("text-valign", "top");
+      children.style("display", "element");
+
+      // [Issue] 숨겨놨던 자식 노드가 보여질 때 position 위치가 엉뚱한 위치로 튀는 이슈가 있어서 아래와 같이 이슈처리함
+      // -> 이로인해 :child 노드들의 layout 세팅이 불가 (검토 필요)
+      // 원인: JavaScript 객체의 참조로 인해 콘솔 로그에서 확장할 때 최신 상태가 반영됨.
+      // 해결 방법: 객체의 값을 복사하여 로그에 출력하여 참조 문제를 피함.
+      let initialPosition = { ...evtTarget.position() };
+      // 자식 노드의 상대 위치를 유지하며 부모 노드의 위치를 변경
+      let offsetX = initialPosition.x - evtTarget.position().x;
+      let offsetY = initialPosition.y - evtTarget.position().y;
+
+      evtTarget.children().forEach((element: any) => {
+        let childPosition = element.position();
+        element.position({
+          x: childPosition.x + offsetX,
+          y: childPosition.y + offsetY
+        });
+      });
+
+      // 부모 노드의 위치를 최종적으로 설정
+      evtTarget.position({
+        x: initialPosition.x,
+        y: initialPosition.y
+      });
+    }
 
     cy.elements().forEach((element: any) => {
       if (element.isNode() && element !== evtTarget) {

--- a/frontend/components/units/filter.vue
+++ b/frontend/components/units/filter.vue
@@ -53,6 +53,7 @@ const getCheckedItem = (item: any) => {
   width: 300px;
   min-height: 400px;
   position: absolute;
+  top: 16px;
   right: 16px;
 
   &-list {

--- a/frontend/components/units/filter.vue
+++ b/frontend/components/units/filter.vue
@@ -19,7 +19,6 @@
           "
         >
           {{ item.label }}
-          {{ item.childCount != 0 ? `(${item.childCount})` : "" }}
         </button>
       </li>
     </ul>

--- a/frontend/pages/cytoscape/dummy_200.json
+++ b/frontend/pages/cytoscape/dummy_200.json
@@ -3,6 +3,32 @@
     {
       "data": {
         "group": "node",
+        "id": "tem_01",
+        "label": "tem_01",
+        "parent": "629969",
+        "color": "#08c",
+        "position": {
+          "x": 300,
+          "y": 100
+        }
+      }
+    },
+    {
+      "data": {
+        "group": "node",
+        "id": "tem_02",
+        "label": "tem_02",
+        "parent": "629969",
+        "color": "#08c",
+        "position": {
+          "x": 400,
+          "y": 300
+        }
+      }
+    },
+    {
+      "data": {
+        "group": "node",
         "id": "sub_01",
         "label": "sub_01",
         "parent": "625795",
@@ -57,7 +83,7 @@
         "group": "node",
         "id": "sub_05",
         "label": "sub_05",
-        "parent": "625795",
+        "parent": "623204",
         "color": "#08c",
         "position": {
           "x": 500,
@@ -70,7 +96,7 @@
         "group": "node",
         "id": "sub_06",
         "label": "sub_06",
-        "parent": "625795",
+        "parent": "623204",
         "color": "#08c",
         "position": {
           "x": 500,
@@ -83,7 +109,7 @@
         "group": "node",
         "id": "sub_07",
         "label": "sub_07",
-        "parent": "625795",
+        "parent": "623204",
         "color": "#08c",
         "position": {
           "x": 500,
@@ -96,7 +122,7 @@
         "group": "node",
         "id": "sub_08",
         "label": "sub_08",
-        "parent": "625795",
+        "parent": "623204",
         "color": "#08c",
         "position": {
           "x": 500,

--- a/frontend/pages/cytoscape/index.vue
+++ b/frontend/pages/cytoscape/index.vue
@@ -1,22 +1,14 @@
 <template>
-  <h3>CYTOSCAPE</h3>
-
   <cytoscape
     :node-data="dummy200Json.elements"
     :style-json="cytoscapeStore.graphStyle"
-    :default-layout="'fcose'"
+    :default-layout="'concentric'"
   ></cytoscape>
 </template>
 
 <script setup lang="ts">
 import Cytoscape from "@comp/cytoscape.vue";
 import dummy200Json from "./dummy_200.json";
-import dummy1400Json from "./dummy_1400.json";
-import style1400Json from "./style_1400.json";
-
-import dummyCompJson from "./dummy_comp.json";
-import styleCompJson from "./style_comp.json";
-
 import { useCytoscapeStore } from "@store/useCytoscapeStore";
 
 const cytoscapeStore = useCytoscapeStore();

--- a/frontend/pages/cytoscape/index.vue
+++ b/frontend/pages/cytoscape/index.vue
@@ -2,7 +2,7 @@
   <cytoscape
     :node-data="dummy200Json.elements"
     :style-json="cytoscapeStore.graphStyle"
-    :default-layout="'concentric'"
+    :default-layout="'random'"
   ></cytoscape>
 </template>
 

--- a/frontend/store/useCytoscapeStore.ts
+++ b/frontend/store/useCytoscapeStore.ts
@@ -123,12 +123,12 @@ export const useCytoscapeStore = defineStore("cytoscape", {
 
         fit: false,
         padding: 30,
-        boundingBox: {
-          x1: 0,
-          y1: 0,
-          x2: 1400,
-          y2: 1000
-        },
+        // boundingBox: {
+        //   x1: 0,
+        //   y1: 0,
+        //   x2: 1400,
+        //   y2: 1000
+        // },
         avoidOverlap: true,
         avoidOverlapPadding: 10,
         nodeDimensionsIncludeLabels: false,
@@ -152,12 +152,12 @@ export const useCytoscapeStore = defineStore("cytoscape", {
 
         fit: false,
         padding: 30,
-        boundingBox: {
-          x1: 0,
-          y1: 0,
-          x2: 1400,
-          y2: 1000
-        },
+        // boundingBox: {
+        //   x1: 0,
+        //   y1: 0,
+        //   x2: 1400,
+        //   y2: 1000
+        // },
         avoidOverlap: true,
         avoidOverlapPadding: 10,
         nodeDimensionsIncludeLabels: false,
@@ -186,12 +186,12 @@ export const useCytoscapeStore = defineStore("cytoscape", {
         clockwise: true,
         equidistant: false,
         minNodeSpacing: 10,
-        boundingBox: {
-          x1: 0,
-          y1: 0,
-          x2: 1400,
-          y2: 1000
-        },
+        // boundingBox: {
+        //   x1: 0,
+        //   y1: 0,
+        //   x2: 1400,
+        //   y2: 1000
+        // },
         avoidOverlap: true,
         nodeDimensionsIncludeLabels: false,
         height: undefined,
@@ -217,15 +217,12 @@ export const useCytoscapeStore = defineStore("cytoscape", {
 
         fit: true,
         padding: 30,
-        boundingBox: {
-          x1: 0,
-          y1: 0,
-          x2: 1400,
-          y2: 1000
-        },
-        animate: true,
-        animationDuration: 500,
-        animationEasing: "ease-in",
+        // boundingBox: {
+        //   x1: 0,
+        //   y1: 0,
+        //   x2: 1400,
+        //   y2: 1000
+        // },
         animateFilter: function (node: any, i: any) {
           return true;
         },
@@ -245,12 +242,12 @@ export const useCytoscapeStore = defineStore("cytoscape", {
         circle: false,
         grid: false,
         spacingFactor: 1.75,
-        boundingBox: {
-          x1: 0,
-          y1: 0,
-          x2: 1400,
-          y2: 1000
-        },
+        // boundingBox: {
+        //   x1: 0,
+        //   y1: 0,
+        //   x2: 1400,
+        //   y2: 1000
+        // },
         avoidOverlap: true,
         nodeDimensionsIncludeLabels: false,
         roots: undefined,
@@ -270,9 +267,6 @@ export const useCytoscapeStore = defineStore("cytoscape", {
         padding: 30,
         ready: function () {},
         stop: function () {},
-        animate: true,
-        animationEasing: "ease-in",
-        animationDuration: 500,
         animateFilter: function (nod: any, i: any) {
           return true;
         },
@@ -314,12 +308,12 @@ export const useCytoscapeStore = defineStore("cytoscape", {
         ungrabifyWhileSimulating: true, // 레이아웃 중 노드를 드래그할 수 없게 함
         fit: true, // 레이아웃 위치 조정 시 뷰포트를 맞춤
         padding: 30, // 시뮬레이션 주위의 여백
-        boundingBox: {
-          x1: 0,
-          y1: 0,
-          x2: 500,
-          y2: 500
-        }, // 레이아웃 경계를 제한함; { x1, y1, x2, y2 } 또는 { x1, y1, w, h } 형식
+        // boundingBox: {
+        //   x1: 0,
+        //   y1: 0,
+        //   x2: 500,
+        //   y2: 500
+        // }, // 레이아웃 경계를 제한함; { x1, y1, x2, y2 } 또는 { x1, y1, w, h } 형식
         nodeDimensionsIncludeLabels: false, // 노드가 사용하는 공간을 결정할 때 레이블을 포함할지 여부
 
         // 레이아웃 이벤트 콜백

--- a/frontend/store/useCytoscapeStore.ts
+++ b/frontend/store/useCytoscapeStore.ts
@@ -6,8 +6,8 @@ export const useCytoscapeStore = defineStore("cytoscape", {
       {
         selector: "node",
         style: {
-          width: "60",
-          height: "60",
+          width: "60px",
+          height: "60px",
           "background-color": "data(color)",
           label: "data(label)",
           "text-valign": "center",
@@ -30,10 +30,17 @@ export const useCytoscapeStore = defineStore("cytoscape", {
           shape: "round-rectangle",
           "background-color": "#bbb",
           "text-outline-color": "#aaa",
-          "corner-radius": "50",
-          padding: 10,
-          width: "16px",
-          height: "16px",
+          "corner-radius": "300",
+          padding: 50,
+          "font-size": "14px",
+          "z-index": "1"
+        }
+      },
+      {
+        selector: ":child",
+        style: {
+          width: "50px",
+          height: "50px",
           "font-size": "14px",
           "z-index": "1"
         }
@@ -121,8 +128,8 @@ export const useCytoscapeStore = defineStore("cytoscape", {
         avoidOverlap: true,
         avoidOverlapPadding: 10,
         nodeDimensionsIncludeLabels: false,
-        spacingFactor: undefined,
         condense: false,
+        spacingFactor: 0.5,
         rows: undefined,
         cols: undefined,
         position: function (node: any) {},
@@ -151,8 +158,9 @@ export const useCytoscapeStore = defineStore("cytoscape", {
           y2: 1000
         },
         avoidOverlap: true,
+        avoidOverlapPadding: 10,
         nodeDimensionsIncludeLabels: false,
-        spacingFactor: undefined,
+        spacingFactor: 1,
         radius: undefined,
         startAngle: (3 / 2) * Math.PI,
         sweep: undefined,
@@ -169,51 +177,6 @@ export const useCytoscapeStore = defineStore("cytoscape", {
         transform: function (node: any, position: any) {
           return position;
         }
-      },
-      cola: {
-        name: "cola",
-
-        animate: false, // 레이아웃이 실행되는 동안 애니메이션을 보여줄지 여부
-        refresh: 1, // 프레임당 틱 수; 높을수록 빠르지만 더 불안정해짐
-        maxSimulationTime: 100, // 레이아웃을 실행할 최대 시간(ms)
-        ungrabifyWhileSimulating: true, // 레이아웃 중 노드를 드래그할 수 없게 함
-        fit: false, // 레이아웃 위치 조정 시 뷰포트를 맞춤
-        padding: 30, // 시뮬레이션 주위의 여백
-        boundingBox: {
-          x1: 0,
-          y1: 0,
-          x2: 1400,
-          y2: 1000
-        }, // 레이아웃 경계를 제한함; { x1, y1, x2, y2 } 또는 { x1, y1, w, h } 형식
-        nodeDimensionsIncludeLabels: false, // 노드가 사용하는 공간을 결정할 때 레이블을 포함할지 여부
-
-        // 레이아웃 이벤트 콜백
-        ready: function () {}, // 레이아웃 준비 완료 시 호출되는 함수
-        stop: function () {}, // 레이아웃 중지 시 호출되는 함수
-
-        // 위치 지정 옵션
-        randomize: false, // 레이아웃 시작 시 랜덤 노드 위치 사용 여부
-        avoidOverlap: true, // true이면 노드 경계 상자가 겹치는 것을 방지함
-        handleDisconnected: true, // true이면 분리된 구성 요소가 겹치는 것을 방지함
-        convergenceThreshold: 0.01, // 알파 값(시스템 에너지)이 이 값 아래로 떨어지면 레이아웃이 중지됨
-        nodeSpacing: function (node) {
-          return 10;
-        }, // 노드 주위의 추가 간격
-        flow: undefined, // DAG/트리 흐름 레이아웃을 사용하려면 지정, 예: { axis: 'y', minSeparation: 30 }
-        alignment: undefined, // 노드에 대한 상대적 정렬 제약, 예: {vertical: [[{node: node1, offset: 0}, {node: node2, offset: 5}]], horizontal: [[{node: node3}, {node: node4}], [{node: node5}, {node: node6}]]}
-        gapInequalities: undefined, // 노드 간의 간격에 대한 불평등 제약 조건 목록, 예: [{"axis":"y", "left":node1, "right":node2, "gap":25}]
-        centerGraph: true, // 그래프의 위치를 중앙에 맞추기 위해 노드 위치를 초기 조정함 (현재 위치에서 레이아웃을 시작하려면 false를 전달)
-
-        // 엣지 길이를 지정하는 다양한 방법
-        // 각 속성은 상수 값이나 `function( edge ){ return 2; }`와 같은 함수가 될 수 있음
-        edgeLength: undefined, // 시뮬레이션에서 엣지 길이를 직접 설정
-        edgeSymDiffLength: undefined, // 시뮬레이션에서 대칭 차 엣지 길이 설정
-        edgeJaccardLength: undefined, // 시뮬레이션에서 자카드 엣지 길이 설정
-
-        // 콜라 알고리즘의 반복; 정의되지 않은 경우 기본값 사용
-        unconstrIter: undefined, // 초기 무제한 레이아웃 반복
-        userConstIter: undefined, // 사용자 지정 제약 조건이 있는 초기 레이아웃 반복
-        allConstIter: undefined // 비중복 포함 모든 제약 조건이 있는 초기 레이아웃 반복
       },
       concentric: {
         name: "concentric",
@@ -271,6 +234,7 @@ export const useCytoscapeStore = defineStore("cytoscape", {
         animateFilter: function (node: any, i: any) {
           return true;
         },
+        spacingFactor: 0.5,
         ready: undefined,
         stop: undefined,
         transform: function (node: any, position: any) {
@@ -313,7 +277,6 @@ export const useCytoscapeStore = defineStore("cytoscape", {
 
         ready: function () {},
         stop: function () {},
-
         animate: true,
         animationEasing: "ease-in",
         animationDuration: 500,
@@ -351,6 +314,51 @@ export const useCytoscapeStore = defineStore("cytoscape", {
 
         minTemp: 1.0
       },
+      cola: {
+        name: "cola",
+
+        animate: false,
+        refresh: 1, // 프레임당 틱 수; 높을수록 빠르지만 더 불안정해짐
+        maxSimulationTime: 100, // 레이아웃을 실행할 최대 시간(ms)
+        ungrabifyWhileSimulating: true, // 레이아웃 중 노드를 드래그할 수 없게 함
+        fit: true, // 레이아웃 위치 조정 시 뷰포트를 맞춤
+        padding: 30, // 시뮬레이션 주위의 여백
+        boundingBox: {
+          x1: 0,
+          y1: 0,
+          x2: 500,
+          y2: 500
+        }, // 레이아웃 경계를 제한함; { x1, y1, x2, y2 } 또는 { x1, y1, w, h } 형식
+        nodeDimensionsIncludeLabels: false, // 노드가 사용하는 공간을 결정할 때 레이블을 포함할지 여부
+
+        // 레이아웃 이벤트 콜백
+        ready: function () {}, // 레이아웃 준비 완료 시 호출되는 함수
+        stop: function () {}, // 레이아웃 중지 시 호출되는 함수
+
+        // 위치 지정 옵션
+        randomize: false, // 레이아웃 시작 시 랜덤 노드 위치 사용 여부
+        avoidOverlap: true, // true이면 노드 경계 상자가 겹치는 것을 방지함
+        handleDisconnected: true, // true이면 분리된 구성 요소가 겹치는 것을 방지함
+        convergenceThreshold: 0.01, // 알파 값(시스템 에너지)이 이 값 아래로 떨어지면 레이아웃이 중지됨
+        nodeSpacing: function (node) {
+          return 10;
+        }, // 노드 주위의 추가 간격
+        flow: undefined, // DAG/트리 흐름 레이아웃을 사용하려면 지정, 예: { axis: 'y', minSeparation: 30 }
+        alignment: undefined, // 노드에 대한 상대적 정렬 제약, 예: {vertical: [[{node: node1, offset: 0}, {node: node2, offset: 5}]], horizontal: [[{node: node3}, {node: node4}], [{node: node5}, {node: node6}]]}
+        gapInequalities: undefined, // 노드 간의 간격에 대한 불평등 제약 조건 목록, 예: [{"axis":"y", "left":node1, "right":node2, "gap":25}]
+        centerGraph: true, // 그래프의 위치를 중앙에 맞추기 위해 노드 위치를 초기 조정함 (현재 위치에서 레이아웃을 시작하려면 false를 전달)
+
+        // 엣지 길이를 지정하는 다양한 방법
+        // 각 속성은 상수 값이나 `function( edge ){ return 2; }`와 같은 함수가 될 수 있음
+        edgeLength: undefined, // 시뮬레이션에서 엣지 길이를 직접 설정
+        edgeSymDiffLength: undefined, // 시뮬레이션에서 대칭 차 엣지 길이 설정
+        edgeJaccardLength: undefined, // 시뮬레이션에서 자카드 엣지 길이 설정
+
+        // 콜라 알고리즘의 반복; 정의되지 않은 경우 기본값 사용
+        unconstrIter: undefined, // 초기 무제한 레이아웃 반복
+        userConstIter: undefined, // 사용자 지정 제약 조건이 있는 초기 레이아웃 반복
+        allConstIter: undefined // 비중복 포함 모든 제약 조건이 있는 초기 레이아웃 반복
+      },
       fcose: {
         name: "fcose",
         // 'draft', 'default' or 'proof'
@@ -363,10 +371,6 @@ export const useCytoscapeStore = defineStore("cytoscape", {
         randomize: true,
         // Whether or not to animate the layout
         animate: false,
-        // Duration of animation in ms, if enabled
-        animationDuration: 1000,
-        // Easing of animation, if enabled
-        animationEasing: undefined,
         // Fit the viewport to the repositioned nodes
         fit: false,
         // Padding around layout

--- a/frontend/store/useCytoscapeStore.ts
+++ b/frontend/store/useCytoscapeStore.ts
@@ -6,17 +6,16 @@ export const useCytoscapeStore = defineStore("cytoscape", {
       {
         selector: "node",
         style: {
-          width: "60px",
-          height: "60px",
+          width: "70",
+          height: "70",
           "background-color": "data(color)",
           label: "data(label)",
           "text-valign": "center",
           "text-halign": "center",
           color: "#333",
-          "font-size": "10",
+          "font-size": "11",
           "border-color": "#333",
           "border-width": "2",
-          "z-index": 1,
           "text-wrap": "ellipsis",
           "text-max-width": "40px"
         }
@@ -24,33 +23,39 @@ export const useCytoscapeStore = defineStore("cytoscape", {
       {
         selector: ":parent",
         style: {
-          label: "",
-          "text-valign": "top",
-          "text-halign": "center",
+          label: "data(label)",
+          width: "70",
+          height: "70",
           shape: "round-rectangle",
-          "background-color": "#bbb",
-          "text-outline-color": "#aaa",
-          "corner-radius": "300",
-          padding: 50,
-          "font-size": "14px",
-          "z-index": "1"
+          "corner-radius": "50%",
+          "text-valign": "center",
+          "text-halign": "center",
+          color: "#333",
+          "font-size": "12",
+          "border-color": "#333",
+          "border-width": "2",
+          "z-index": 11,
+          "text-wrap": "wrap",
+          "text-max-width": "100px",
+          "font-weight": "bold",
+          "z-index": 999
+          // "z-compound-depth": "top"
         }
       },
       {
         selector: ":child",
         style: {
-          width: "50px",
-          height: "50px",
-          "font-size": "14px",
-          "z-index": "1"
+          width: "45px",
+          height: "45px",
+          "font-size": "10"
         }
       },
       {
         selector: "node.highlight",
         style: {
           "font-size": "12",
-          "z-index": 2,
-          "text-wrap": "wrap"
+          "text-wrap": "wrap",
+          "z-index": 1
         }
       },
       {
@@ -58,7 +63,7 @@ export const useCytoscapeStore = defineStore("cytoscape", {
         style: {
           "background-blacken": -0.5,
           "border-opacity": 0.5,
-          "font-size": "10",
+          "font-size": "11",
           "text-wrap": "ellipsis",
           "text-opacity": 0.5,
           "z-index": 0
@@ -80,18 +85,17 @@ export const useCytoscapeStore = defineStore("cytoscape", {
           "curve-style": "bezier",
           "target-arrow-color": "#333",
           "target-arrow-shape": "triangle",
-          "font-size": "10",
-          color: "#5F5E5E",
-          "z-index": 1
+          "font-size": "11",
+          color: "#5F5E5E"
         }
       },
       {
         selector: "edge.highlight",
         style: {
           width: 2,
-          "z-index": 2,
           "font-size": "12",
-          "arrow-scale": 1.2
+          "arrow-scale": 1.2,
+          "z-index": 1
         }
       },
       {
@@ -134,9 +138,6 @@ export const useCytoscapeStore = defineStore("cytoscape", {
         cols: undefined,
         position: function (node: any) {},
         sort: undefined,
-        animate: true,
-        animationDuration: 500,
-        animationEasing: "ease-in",
         animateFilter: function (node: any, i: any) {
           return true;
         },
@@ -166,9 +167,6 @@ export const useCytoscapeStore = defineStore("cytoscape", {
         sweep: undefined,
         clockwise: true,
         sort: undefined,
-        animate: true,
-        animationDuration: 500,
-        animationEasing: "ease-in",
         animateFilter: function (node: any, i: any) {
           return true;
         },
@@ -205,9 +203,6 @@ export const useCytoscapeStore = defineStore("cytoscape", {
         levelWidth: function (nodes: any) {
           return nodes.maxDegree() / 4;
         },
-        animate: true,
-        animationDuration: 500,
-        animationEasing: "ease-in",
         animateFilter: function (node: any, i: any) {
           return true;
         },
@@ -234,7 +229,7 @@ export const useCytoscapeStore = defineStore("cytoscape", {
         animateFilter: function (node: any, i: any) {
           return true;
         },
-        spacingFactor: 0.5,
+        spacingFactor: 1,
         ready: undefined,
         stop: undefined,
         transform: function (node: any, position: any) {
@@ -260,9 +255,6 @@ export const useCytoscapeStore = defineStore("cytoscape", {
         nodeDimensionsIncludeLabels: false,
         roots: undefined,
         depthSort: undefined,
-        animate: true,
-        animationDuration: 500,
-        animationEasing: "ease-in",
         animateFilter: function (node: any, i: any) {
           return true;
         },
@@ -274,7 +266,8 @@ export const useCytoscapeStore = defineStore("cytoscape", {
       },
       cose: {
         name: "cose",
-
+        fit: false,
+        padding: 30,
         ready: function () {},
         stop: function () {},
         animate: true,
@@ -285,8 +278,6 @@ export const useCytoscapeStore = defineStore("cytoscape", {
         },
         animationThreshold: 250,
         refresh: 20,
-        fit: true,
-        padding: 30,
         boundingBox: {
           x1: 0,
           y1: 0,


### PR DESCRIPTION
## 유형
- Feature (기능 추가 or 개선)

## 이슈 링크
https://mobigen.atlassian.net/browse/FAB2023-835
https://mobigen.atlassian.net/browse/FAB2023-751

## 수정 내용
- [x]  layout 설정 방법 수정
- child 노드를 제외한 노드들을 새로 담아 layout 설정 적용 
- [x]  parent 노드 를 클릭했을 때 child 노드가 보이도록 개선
- (+) 노드 바깥을 클릭했을 때 초기화(안보이는 상태)
- (+) 우측 필터에서 부모 노드 hide -> show 일 경우 초기화(안보이는 상태)
- [x]  parent 노드의 label + (노드 개수) 주입 방식 변경
- [x] cytoscapeStore, 샘플 데이터 수정 
## TODO List
- [x] parent 노드가 레이아웃에 포함이 안됨
- [x] parent 노드를 최초로 클릭 했을 때 현재 position과 다른 위치로 이동되는 이슈가 있음. (최초 클릭 시에만 이슈가 있음)
- [x] parent 노드의  z-index 수정 필요, `z-compound-depth` 으로 parent 를 뜨게 할 수 있으나, 속한 child 가 밑으로 가라앉는 이슈가 있음…
